### PR TITLE
dont use circle shader for poi names

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -490,6 +490,9 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
                     var lines = labelText.Split('\n');
                     var mainLabel = lines[0];
 
+                    var circleShader = handle.GetShader(); // StarHorizon
+                    handle.UseShader(null); // StarHorizon
+
                     // Draw main ship label with company color if available
                     handle.DrawString(Font, (uiPosition + labelOffset) * UIScale, mainLabel, UIScale * 0.9f, displayColor);
 
@@ -505,6 +508,8 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
                         };
                         handle.DrawString(Font, (uiPosition + coordOffset) * UIScale, coordsText, 0.7f * UIScale, displayColor);
                     }
+
+                    handle.UseShader(circleShader); // StarHorizon
                 }
 
                 NfAddBlipToList(blipDataList, isOutsideRadarCircle, uiPosition, uiXCentre, uiYCentre, labelColor, gUid); // Frontier code


### PR DESCRIPTION
**ОПИСАНИЕ**

<!--здесь вы кратко описываете суть изменений, просто чтобы понимать, о чем ПР-->
Убрал применение шейдера, который обрезает все, что не в круге, для названия шаттлов и точек интереса.

<details>
  <summary>МЕДИА</summary>
<img width="1240" height="1330" alt="image" src="https://github.com/user-attachments/assets/c65e4682-df3c-4bed-b2ac-95e7c83b04fd" />

-
</details>

<!--сюда вы прикладываете скриншоты и видео, пустая строка промежуточная обязательна-->

<details>
  <summary>КАК ПРОВЕРИТЬ</summary>
- [ ] Зайти на локалку и проверить, не знаю что тут еще писать. В медиа прикрепил скриншот как изменится
</details>

<!--здесь вы прописываете, какие действия необходимо провести, чтобы проверить ПР, пустая строка промежуточная обязательна-->

**ЧЕЙНДЖЛОГ**

:cl: BadRyuner
- tweak: название объектов на радаре больше не обрезается

<!--здесь вы прописываете чейнджлог, который пойдет в наш дискорд, так что необходимо все расписывать подробно, например:
:cl: Lemird
- add: возвращен трусомат, ищите его в карго на каждой станции!
- remove: удален трусомат
- tweak: изменен состав трусомата
- fix: пофикшены баги трусомата
-->
